### PR TITLE
Remove a layer in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN mkdir /web-ui-amt
 
 WORKDIR /web-ui-amt
 
-COPY package.json package.json
-COPY package-lock.json package-lock.json
+COPY package.json package-lock.json .
 
 RUN npm install
 


### PR DESCRIPTION
😄 

[COPY](https://docs.docker.com/engine/reference/builder/#copy) supports multiple source file:

> Multiple <src> resources may be specified but the paths of files and directories will be interpreted as relative to the source of the context of the build.

Doing this like this removes one layer in the Dockerfile which makes the Docker image slightly smaller. More on minimizing the number of layers: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers